### PR TITLE
Allow cost functions to be interchanged in `optimize-variational-circuit`

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     ),
     install_requires=[
         "z-quantum-core",
+        "qe-openfermion",
         "pytest>=5.3.5",
         "marshmallow>=3.4.0",
         "cma==2.7.0",

--- a/templates/optimizers.yaml
+++ b/templates/optimizers.yaml
@@ -40,65 +40,12 @@ spec:
             path: /app/python_script.py
             raw:
               data: |
-                import os
-                from zquantum.optimizers.utils import save_optimization_results
-                from zquantum.core.circuit import (
-                    load_circuit_template,
-                    load_circuit_template_params,
-                    save_circuit_template_params,
-                    load_parameter_grid,
-                    load_circuit_connectivity,
-                )
-                from qeopenfermion import load_qubit_operator
-                from zquantum.core.utils import create_object, load_noise_model
-                import json
+                from zquantum.optimizers.utils import optimize_variational_circuit
 
-                ansatz = load_circuit_template("ansatz.json")
-
-                if os.path.isfile("initial_parameters.json"):
-                    initial_parameters = load_circuit_template_params("initial_parameters.json")
-                else:
-                    initial_parameters = None
-
-                # Load qubit op
-                operator = load_qubit_operator("qubitop.json")
-
-                # Load parameter grid
-                if os.path.isfile("parameter_grid.json"):
-                    grid = load_parameter_grid("parameter_grid.json")
-                else:
-                    grid = None
                 optimizer_specs = {{inputs.parameters.optimizer-specs}}
-                if grid is not None and optimizer_specs["function_name"] == "GridSearchOptimizer":
-                    optimizer = create_object(optimizer_specs, grid=grid)
-                else:
-                    optimizer = create_object(optimizer_specs)
-
                 backend_specs = {{inputs.parameters.backend-specs}}
-                if os.path.isfile("noise_model.json"):
-                    backend_specs["noise_model"] = load_noise_model("noise_model.json")
-                if os.path.isfile("device_connectivity.json"):
-                    backend_specs["device_connectivity"] = load_circuit_connectivity(
-                        "device_connectivity.json"
-                    )
-                backend = create_object(backend_specs)
-
                 cost_function_specs = {{inputs.parameters.cost-function-specs}}
-                cost_function_specs["target_operator"] = operator
-                cost_function_specs["ansatz"] = ansatz
-                cost_function_specs["backend"] = backend
-                cost_function = create_object(cost_function_specs)
-                if os.path.isfile("constraint_operator.json"):
-                    constraint_operator = load_qubit_operator("constraint_operator.json")
-                    cost_function_specs["target_operator"] = constraint_operator
-                    constraint_cost_function = create_object(cost_function_specs)
-                    constraint_functions = ({"type": "eq", "fun": constraint_cost_function.evaluate},)
-                    optimizer.constraints = constraint_functions
-
-                opt_results = optimizer.minimize(cost_function, initial_parameters)
-
-                save_optimization_results(opt_results, "optimization-results.json")
-                save_circuit_template_params(opt_results.opt_params, "optimized_parameters.json"
+                optimize_variational_circuit(optimizer_specs, backend_specs, cost_function_specs)
         outputs:
           artifacts:
             - name: optimization-results

--- a/templates/optimizers.yaml
+++ b/templates/optimizers.yaml
@@ -68,13 +68,13 @@ spec:
                     grid = load_parameter_grid("parameter_grid.json")
                 else:
                     grid = None
-                optimizer_specs = {{inputs.parameters.optimizer - specs}}
+                optimizer_specs = {{inputs.parameters.optimizer-specs}}
                 if grid is not None and optimizer_specs["function_name"] == "GridSearchOptimizer":
                     optimizer = create_object(optimizer_specs, grid=grid)
                 else:
                     optimizer = create_object(optimizer_specs)
 
-                backend_specs = {{inputs.parameters.backend - specs}}
+                backend_specs = {{inputs.parameters.backend-specs}}
                 if os.path.isfile("noise_model.json"):
                     backend_specs["noise_model"] = load_noise_model("noise_model.json")
                 if os.path.isfile("device_connectivity.json"):
@@ -83,7 +83,7 @@ spec:
                     )
                 backend = create_object(backend_specs)
 
-                cost_function_specs = {{inputs.parameters.cost - function - specs}}
+                cost_function_specs = {{inputs.parameters.cost-function-specs}}
                 cost_function_specs["target_operator"] = operator
                 cost_function_specs["ansatz"] = ansatz
                 cost_function_specs["backend"] = backend

--- a/templates/optimizers.yaml
+++ b/templates/optimizers.yaml
@@ -6,6 +6,7 @@ spec:
         parameters:
           - name: backend-specs
           - name: optimizer-specs
+          - name: cost-function-specs
           - name: command
             value: bash main_script.sh
         artifacts:
@@ -41,53 +42,63 @@ spec:
               data: |
                 import os
                 from zquantum.optimizers.utils import save_optimization_results
-                from zquantum.core.cost_function import EvaluateOperatorCostFunction
-                from zquantum.core.circuit import load_circuit_template, load_circuit_template_params, save_circuit_template_params, load_parameter_grid, load_circuit_connectivity
+                from zquantum.core.circuit import (
+                    load_circuit_template,
+                    load_circuit_template_params,
+                    save_circuit_template_params,
+                    load_parameter_grid,
+                    load_circuit_connectivity,
+                )
                 from qeopenfermion import load_qubit_operator
                 from zquantum.core.utils import create_object, load_noise_model
                 import json
 
-                ansatz = load_circuit_template('ansatz.json')
+                ansatz = load_circuit_template("ansatz.json")
 
-                if os.path.isfile('initial_parameters.json'):
-                  initial_parameters = load_circuit_template_params('initial_parameters.json')
+                if os.path.isfile("initial_parameters.json"):
+                    initial_parameters = load_circuit_template_params("initial_parameters.json")
                 else:
-                  initial_parameters = None
+                    initial_parameters = None
 
                 # Load qubit op
-                operator = load_qubit_operator('qubitop.json')
+                operator = load_qubit_operator("qubitop.json")
 
                 # Load parameter grid
-                if os.path.isfile('parameter_grid.json'):
-                  grid = load_parameter_grid('parameter_grid.json')
+                if os.path.isfile("parameter_grid.json"):
+                    grid = load_parameter_grid("parameter_grid.json")
                 else:
-                  grid = None
-                optimizer_specs = {{inputs.parameters.optimizer-specs}}
-                if grid is not None and optimizer_specs['function_name'] == 'GridSearchOptimizer':
-                  optimizer = create_object(optimizer_specs, grid=grid)
+                    grid = None
+                optimizer_specs = {{inputs.parameters.optimizer - specs}}
+                if grid is not None and optimizer_specs["function_name"] == "GridSearchOptimizer":
+                    optimizer = create_object(optimizer_specs, grid=grid)
                 else:
-                  optimizer = create_object(optimizer_specs)
-                  
-                backend_specs = {{inputs.parameters.backend-specs}}
-                if os.path.isfile('noise_model.json'):
-                  backend_specs["noise_model"] = load_noise_model("noise_model.json")
+                    optimizer = create_object(optimizer_specs)
+
+                backend_specs = {{inputs.parameters.backend - specs}}
+                if os.path.isfile("noise_model.json"):
+                    backend_specs["noise_model"] = load_noise_model("noise_model.json")
                 if os.path.isfile("device_connectivity.json"):
                     backend_specs["device_connectivity"] = load_circuit_connectivity(
                         "device_connectivity.json"
                     )
                 backend = create_object(backend_specs)
 
-                cost_function = EvaluateOperatorCostFunction(operator, ansatz, backend)
-                if os.path.isfile('constraint_operator.json'):
-                  constraint_operator = load_qubit_operator('constraint_operator.json')
-                  constraint_cost_function = EvaluateOperatorCostFunction(constraint_operator, ansatz, backend)
-                  constraint_functions = ({'type': 'eq', 'fun': constraint_cost_function.evaluate},)
-                  optimizer.constraints = constraint_functions
+                cost_function_specs = {{inputs.parameters.cost - function - specs}}
+                cost_function_specs["target_operator"] = operator
+                cost_function_specs["ansatz"] = ansatz
+                cost_function_specs["backend"] = backend
+                cost_function = create_object(cost_function_specs)
+                if os.path.isfile("constraint_operator.json"):
+                    constraint_operator = load_qubit_operator("constraint_operator.json")
+                    cost_function_specs["target_operator"] = constraint_operator
+                    constraint_cost_function = create_object(cost_function_specs)
+                    constraint_functions = ({"type": "eq", "fun": constraint_cost_function.evaluate},)
+                    optimizer.constraints = constraint_functions
 
                 opt_results = optimizer.minimize(cost_function, initial_parameters)
 
-                save_optimization_results(opt_results, 'optimization-results.json')
-                save_circuit_template_params(opt_results.opt_params, 'optimized_parameters.json')
+                save_optimization_results(opt_results, "optimization-results.json")
+                save_circuit_template_params(opt_results.opt_params, "optimized_parameters.json"
         outputs:
           artifacts:
             - name: optimization-results


### PR DESCRIPTION
This allows different cost functions to be used in the optimization loop. As an example, see [this](https://github.com/zapatacomputing/z-quantum-vqe/blob/estimator/examples/hydrogen.yaml#L162).