### PR TITLE
Allow cost functions to be interchanged and update to latest version of z-quantum-core

### DIFF
--- a/src/python/zquantum/optimizers/cma_es_optimizer.py
+++ b/src/python/zquantum/optimizers/cma_es_optimizer.py
@@ -49,7 +49,7 @@ class CMAESOptimizer(Optimizer):
         history = []
 
         def wrapped_cost_function(params):
-            value = cost_function.evaluate(params)
+            value = cost_function.evaluate(params).value
             history.append(cost_function.evaluations_history[-1])
             print(f"Function evaluation {len(history)}: {value}", flush=True)
             print(f"{params}", flush=True)

--- a/src/python/zquantum/optimizers/daemon_optimizer/optimize/_api_test.py
+++ b/src/python/zquantum/optimizers/daemon_optimizer/optimize/_api_test.py
@@ -7,8 +7,8 @@ import unittest
 import random
 import subprocess
 
-class TestOptimizationServer(unittest.TestCase):
 
+class TestOptimizationServer(unittest.TestCase):
     def setUp(self):
         self.port = "1234"
         self.ipaddress = "testing-ip"
@@ -19,14 +19,15 @@ class TestOptimizationServer(unittest.TestCase):
         params = [0, 0]
         optimizer = MockOptimizer()
         # When
-        opt_results = optimize_variational_circuit_with_proxy(params,
-                        optimizer, client)
+        opt_results = optimize_variational_circuit_with_proxy(params, optimizer, client)
         # Then
-        self.assertEqual(opt_results['opt_value'], 0)
-        self.assertEqual(len(opt_results['opt_params']), 2)
-        self.assertEqual(opt_results['history'][0]['optimization-evaluation-ids'], ['MOCKED-ID'])
-        self.assertIn('value', opt_results['history'][0].keys())
-        self.assertIn('params', opt_results['history'][0].keys())
+        self.assertEqual(opt_results["opt_value"].value, 0)
+        self.assertEqual(len(opt_results["opt_params"]), 2)
+        self.assertEqual(
+            opt_results["history"][0]["optimization-evaluation-ids"], ["MOCKED-ID"]
+        )
+        self.assertIn("value", opt_results["history"][0].keys())
+        self.assertIn("params", opt_results["history"][0].keys())
 
     def test_optimize_variational_circuit_with_proxy_x_squared(self):
         # Given
@@ -34,14 +35,15 @@ class TestOptimizationServer(unittest.TestCase):
         params = [4]
         optimizer = MockOptimizer()
         # When
-        opt_results = optimize_variational_circuit_with_proxy(params,
-                        optimizer, client)
+        opt_results = optimize_variational_circuit_with_proxy(params, optimizer, client)
         # Then
-        self.assertGreater(opt_results['opt_value'], 0)
-        self.assertEqual(len(opt_results['opt_params']), 1)
-        self.assertEqual(opt_results['history'][0]['optimization-evaluation-ids'], ['MOCKED-ID'])
-        self.assertIn('value', opt_results['history'][0].keys())
-        self.assertIn('params', opt_results['history'][0].keys())
+        self.assertGreater(opt_results["opt_value"].value, 0)
+        self.assertEqual(len(opt_results["opt_params"]), 1)
+        self.assertEqual(
+            opt_results["history"][0]["optimization-evaluation-ids"], ["MOCKED-ID"]
+        )
+        self.assertIn("value", opt_results["history"][0].keys())
+        self.assertIn("params", opt_results["history"][0].keys())
 
     def test_optimize_variational_circuit_with_proxy_errors(self):
         client = MockedClient(self.ipaddress, self.port)
@@ -50,13 +52,27 @@ class TestOptimizationServer(unittest.TestCase):
         # self.assertRaises(ValueError, lambda: optimize_variational_circuit_with_proxy(
         #     "Not initial params", optimizer, client))
 
-        self.assertRaises(AttributeError, lambda: optimize_variational_circuit_with_proxy(
-            params, "Not an optimizer object", "Not a client"))
+        self.assertRaises(
+            AttributeError,
+            lambda: optimize_variational_circuit_with_proxy(
+                params, "Not an optimizer object", "Not a client"
+            ),
+        )
 
-        self.assertRaises(AttributeError, lambda: optimize_variational_circuit_with_proxy(
-            params, optimizer, "Not a client"))
- 
+        self.assertRaises(
+            AttributeError,
+            lambda: optimize_variational_circuit_with_proxy(
+                params, optimizer, "Not a client"
+            ),
+        )
+
     @classmethod
     def tearDownClass(self):
-        subprocess.call(["rm", 'client_mock_evaluation_result.json',
-                         'current_optimization_params.json'])
+        subprocess.call(
+            [
+                "rm",
+                "client_mock_evaluation_result.json",
+                "current_optimization_params.json",
+            ]
+        )
+

--- a/src/python/zquantum/optimizers/daemon_optimizer/optimize/cost_function.py
+++ b/src/python/zquantum/optimizers/daemon_optimizer/optimize/cost_function.py
@@ -1,5 +1,5 @@
 from zquantum.core.interfaces.cost_function import CostFunction
-from zquantum.core.utils import save_list, load_value_estimate
+from zquantum.core.utils import save_list, load_value_estimate, ValueEstimate
 from zquantum.core.circuit import save_circuit_template_params
 import time
 import io
@@ -27,7 +27,7 @@ class ProxyCostFunction(CostFunction):
         self.gradient_type = "finite_difference"
         self.epsilon = epsilon
 
-    def evaluate(self, parameters):
+    def evaluate(self, parameters) -> ValueEstimate:
         """
         Evaluates the value of the cost function for given parameters.
 
@@ -40,7 +40,7 @@ class ProxyCostFunction(CostFunction):
         value = self._evaluate(parameters)
         return value
 
-    def _evaluate(self, parameters):
+    def _evaluate(self, parameters) -> ValueEstimate:
         """
         Evaluates the value of the cost function for given parameters by communicating with client.
 
@@ -77,11 +77,9 @@ class ProxyCostFunction(CostFunction):
                 "optimization-evaluation-ids"
             ].append(evaluation_id)
             self.evaluations_history[self.current_iteration]["params"] = parameters
-            self.evaluations_history[self.current_iteration][
-                "value"
-            ] = value_estimate.value
+            self.evaluations_history[self.current_iteration]["value"] = value_estimate
 
-        return value_estimate.value
+        return value_estimate
 
     def callback(self, parameters):
         """

--- a/src/python/zquantum/optimizers/daemon_optimizer/optimize/cost_function_test.py
+++ b/src/python/zquantum/optimizers/daemon_optimizer/optimize/cost_function_test.py
@@ -5,6 +5,7 @@ from zquantum.core.interfaces.cost_function_test import CostFunctionTests
 
 from .cost_function import ProxyCostFunction
 from .client_mock import MockedClient
+from zquantum.core.utils import ValueEstimate
 
 
 class TestProxyCostFunction(unittest.TestCase, CostFunctionTests):
@@ -21,7 +22,7 @@ class TestProxyCostFunction(unittest.TestCase, CostFunctionTests):
         client = MockedClient(self.ipaddress, self.port, "return_x_squared")
         params = np.array([4])
         cost_function = ProxyCostFunction(client)
-        target_value = 16
+        target_value = ValueEstimate(16)
 
         # When
         value = cost_function.evaluate(params)
@@ -36,7 +37,7 @@ class TestProxyCostFunction(unittest.TestCase, CostFunctionTests):
         client = MockedClient(self.ipaddress, self.port, "return_x_squared")
         params = np.array([4])
         cost_function = ProxyCostFunction(client)
-        target_value = 16
+        target_value = ValueEstimate(16)
 
         # When
         value_1 = cost_function.evaluate(params)

--- a/src/python/zquantum/optimizers/grid_search.py
+++ b/src/python/zquantum/optimizers/grid_search.py
@@ -48,7 +48,7 @@ class GridSearchOptimizer(Optimizer):
         nfev = 0
 
         for params in self.grid.params_list:
-            value = cost_function.evaluate(params)
+            value = cost_function.evaluate(params).value
             if self.keep_value_history:
                 history.append({"params": params, "value": value})
             nfev += 1

--- a/src/python/zquantum/optimizers/qiskit_optimizer.py
+++ b/src/python/zquantum/optimizers/qiskit_optimizer.py
@@ -51,7 +51,7 @@ class QiskitOptimizer(Optimizer):
         def wrapped_(params):
             history.append({"params": params})
             if self.keep_value_history:
-                value = cost_function.evaluate(params)
+                value = cost_function.evaluate(params).value
                 history[-1]["value"] = value
                 print(f"Iteration {len(history)}: {value}", flush=True)
             else:
@@ -59,9 +59,10 @@ class QiskitOptimizer(Optimizer):
             print(f"{params}", flush=True)
 
         number_of_variables = len(initial_params)
+        cost_function_wrapper = lambda params: cost_function.evaluate(params).value
         solution, value, nit = optimizer.optimize(
             num_vars=number_of_variables,
-            objective_function=cost_function.evaluate,
+            objective_function=cost_function_wrapper,
             initial_point=initial_params,
             gradient_function=cost_function.get_gradient,
         )

--- a/src/python/zquantum/optimizers/scipy_optimizer.py
+++ b/src/python/zquantum/optimizers/scipy_optimizer.py
@@ -62,8 +62,9 @@ class ScipyOptimizer(Optimizer):
 
         if callback is None:
             callback = default_callback
+        cost_function_wrapper = lambda params: cost_function.evaluate(params).value
         result = scipy.optimize.minimize(
-            cost_function.evaluate,
+            cost_function_wrapper,
             initial_params,
             method=self.method,
             options=self.options,

--- a/src/python/zquantum/optimizers/scipy_optimizer_test.py
+++ b/src/python/zquantum/optimizers/scipy_optimizer_test.py
@@ -25,7 +25,10 @@ class ScipyOptimizerTests(unittest.TestCase, OptimizerTests):
             rosenbrock_function, gradient_type="finite_difference"
         )
         constraint_cost_function = BasicCostFunction(sum_x_squared)
-        constraints = ({"type": "eq", "fun": constraint_cost_function.evaluate},)
+        constraint_cost_function_wrapper = lambda params: constraint_cost_function.evaluate(
+            params
+        ).value
+        constraints = ({"type": "eq", "fun": constraint_cost_function_wrapper},)
         optimizer = ScipyOptimizer(method="SLSQP", constraints=constraints)
         initial_params = np.array([1, 1])
         target_params = np.array([0, 0])

--- a/src/python/zquantum/optimizers/utils_test.py
+++ b/src/python/zquantum/optimizers/utils_test.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 import os
 from .utils import (
+    ValueEstimate,
     load_optimization_results,
     save_optimization_results,
     validate_optimization_results,
@@ -57,6 +58,45 @@ class TestUtils(unittest.TestCase):
         opt_results["history"] = [
             {"value": 0.1, "params": np.array([1.0, 2.0])},
             {"value": -0.1, "params": np.array([-1.0, 2.0])},
+        ]
+        opt_results["opt_value"] = 5
+        opt_results["opt_params"] = np.array([1.0, 2.0])
+
+        save_optimization_results(opt_results, "opt_result.json")
+        loaded_result = load_optimization_results("opt_result.json")
+
+        for key in opt_results:
+            if key != "history" and key != "opt_params":
+                self.assertEqual(opt_results[key], loaded_result[key])
+
+        self.assertTrue(
+            np.allclose(opt_results["opt_params"], loaded_result["opt_params"])
+        )
+        # Verify that the optimization history is the same
+        self.assertEqual(len(opt_results["history"]), len(loaded_result["history"]))
+        for i in range(len(opt_results["history"])):
+            self.assertAlmostEqual(
+                opt_results["history"][i]["value"], loaded_result["history"][i]["value"]
+            )
+            self.assertTrue(
+                np.allclose(
+                    opt_results["history"][i]["params"],
+                    loaded_result["history"][i]["params"],
+                )
+            )
+
+        os.remove("opt_result.json")
+
+    def test_optimization_result_io_with_value_estimates(self):
+        opt_results = OptimizeResult({})
+        opt_results["value"] = ValueEstimate(0.1)
+        opt_results["status"] = 0
+        opt_results["success"] = True
+        opt_results["nfev"] = 5
+        opt_results["nit"] = 2
+        opt_results["history"] = [
+            {"value": ValueEstimate(0.1), "params": np.array([1.0, 2.0])},
+            {"value": ValueEstimate(-0.1), "params": np.array([-1.0, 2.0])},
         ]
         opt_results["opt_value"] = 5
         opt_results["opt_params"] = np.array([1.0, 2.0])

--- a/templates/optimizers.yaml
+++ b/templates/optimizers.yaml
@@ -90,7 +90,7 @@ spec:
               constraint_functions = (
                   {"type": "eq", "fun": constraint_cost_function_wrapper},
               )
-              optimizer.constraints = constraint_functionss
+              optimizer.constraints = constraint_functions
 
             opt_results = optimizer.minimize(cost_function, initial_parameters)
 

--- a/templates/optimizers.yaml
+++ b/templates/optimizers.yaml
@@ -6,6 +6,7 @@ spec:
       parameters:
       - name: backend-specs
       - name: optimizer-specs
+      - name: cost-function-specs
       - name: command
         value: bash main_script.sh
       artifacts:
@@ -41,7 +42,6 @@ spec:
           data: |
             import os
             from zquantum.optimizers.utils import save_optimization_results
-            from zquantum.core.cost_function import EvaluateOperatorCostFunction
             from zquantum.core.circuit import load_circuit_template, load_circuit_template_params, save_circuit_template_params, load_parameter_grid, load_circuit_connectivity
             from qeopenfermion import load_qubit_operator
             from zquantum.core.utils import create_object, load_noise_model
@@ -77,12 +77,20 @@ spec:
                 )
             backend = create_object(backend_specs)
 
-            cost_function = EvaluateOperatorCostFunction(operator, ansatz, backend)
-            if os.path.isfile('constraint_operator.json'):
-              constraint_operator = load_qubit_operator('constraint_operator.json')
-              constraint_cost_function = EvaluateOperatorCostFunction(constraint_operator, ansatz, backend)
-              constraint_functions = ({'type': 'eq', 'fun': constraint_cost_function.evaluate},)
-              optimizer.constraints = constraint_functions
+            cost_function_specs = {{inputs.parameters.cost-function-specs}}
+            cost_function_specs["target_operator"] = operator
+            cost_function_specs["ansatz"] = ansatz
+            cost_function_specs["backend"] = backend
+            cost_function = create_object(cost_function_specs)
+            if os.path.isfile("constraint_operator.json"):
+              constraint_operator = load_qubit_operator("constraint_operator.json")
+              cost_function_specs["target_operator"] = constraint_operator
+              constraint_cost_function = create_object(cost_function_specs)
+              constraint_cost_function_wrapper = lambda params: constraint_cost_function.evaluate(params).value
+              constraint_functions = (
+                  {"type": "eq", "fun": constraint_cost_function_wrapper},
+              )
+              optimizer.constraints = constraint_functionss
 
             opt_results = optimizer.minimize(cost_function, initial_parameters)
 


### PR DESCRIPTION
This PR allows different cost functions to be used in the optimization loop. As an example, see this. It also updates to the latest version of z-quantum-core (that will be merged shortly).

This should not be merged until zapatacomputing/z-quantum-core#44 is merged. CICD checks will fail until then as well. 