### PR TITLE
Support interchanging estimators in cost-function-specs

### DIFF
--- a/templates/optimizers.yaml
+++ b/templates/optimizers.yaml
@@ -78,6 +78,9 @@ spec:
             backend = create_object(backend_specs)
 
             cost_function_specs = {{inputs.parameters.cost-function-specs}}
+            estimator_specs = cost_function_specs.pop("estimator-specs", None)
+            if estimator_specs is not None:
+              cost_function_specs["estimator"] = create_object(estimator_specs)
             cost_function_specs["target_operator"] = operator
             cost_function_specs["ansatz"] = ansatz
             cost_function_specs["backend"] = backend


### PR DESCRIPTION
This PR allows users to pass a different estimator when they use the `optimize-variational-circuit` resource. Here is an example of how to use the `ExactEstimator` from `zquantum.core.estimator`:

```yaml
 - cost-function-specs: "{'module_name': 'zquantum.core.cost_function', 'function_name': 'AnsatzBasedCostFunction', 'estimator-specs': { 'module_name': 'zquantum.core.estimator', 'function_name': 'SomeEstimator', 'epsilon': 0.7 }}"
```
