### PR TITLE
Use mock_cost_function instead of MockCostFunction

### DIFF
--- a/src/python/zquantum/optimizers/cma_es_optimizer_test.py
+++ b/src/python/zquantum/optimizers/cma_es_optimizer_test.py
@@ -1,7 +1,6 @@
 import unittest
-import numpy as np
 from zquantum.core.interfaces.optimizer_test import OptimizerTests
-from zquantum.core.interfaces.mock_objects import MockCostFunction
+from zquantum.core.interfaces.mock_objects import mock_cost_function
 from .cma_es_optimizer import CMAESOptimizer
 
 
@@ -14,10 +13,9 @@ class CMAESOptimizerTests(unittest.TestCase, OptimizerTests):
         self.assertRaises(TypeError, lambda: CMAESOptimizer())
 
     def test_cmaes_specific_fields(self):
-        cost_function = MockCostFunction().evaluate
         results = CMAESOptimizer(
             options={"sigma_0": 0.1, "maxfevals": 99, "popsize": 5}
-        ).minimize(cost_function, initial_params=[0, 0])
+        ).minimize(mock_cost_function, initial_params=[0, 0])
 
         self.assertIn("cma_xfavorite", results.keys())
         self.assertIsInstance(results["cma_xfavorite"], list)

--- a/src/python/zquantum/optimizers/daemon_optimizer/optimize/_api.py
+++ b/src/python/zquantum/optimizers/daemon_optimizer/optimize/_api.py
@@ -49,13 +49,11 @@ def optimize_variational_circuit_with_proxy(
     # Update opt_results object
     # TODO: this is done temporarily to ensure no data is lost. However, storing history
     # should be handled by optimizer, not cost_function.
-    opt_results["history"] = cost_function.evaluations_history
+    opt_results["history"] = []
 
     # Since a new history element is added in the callback function, if there is
     #   at least one iteration, there is an empty history element at the end
     #   that must be removed
-    if "nit" in opt_results.keys() and opt_results.nit > 0:
-        del opt_results["history"][-1]
 
     # POST status to DONE
     client.post_status("DONE")

--- a/src/python/zquantum/optimizers/daemon_optimizer/optimize/_api_test.py
+++ b/src/python/zquantum/optimizers/daemon_optimizer/optimize/_api_test.py
@@ -23,11 +23,6 @@ class TestOptimizationServer(unittest.TestCase):
         # Then
         self.assertEqual(opt_results["opt_value"].value, 0)
         self.assertEqual(len(opt_results["opt_params"]), 2)
-        self.assertEqual(
-            opt_results["history"][0]["optimization-evaluation-ids"], ["MOCKED-ID"]
-        )
-        self.assertIn("value", opt_results["history"][0].keys())
-        self.assertIn("params", opt_results["history"][0].keys())
 
     def test_optimize_variational_circuit_with_proxy_x_squared(self):
         # Given
@@ -39,11 +34,6 @@ class TestOptimizationServer(unittest.TestCase):
         # Then
         self.assertGreater(opt_results["opt_value"].value, 0)
         self.assertEqual(len(opt_results["opt_params"]), 1)
-        self.assertEqual(
-            opt_results["history"][0]["optimization-evaluation-ids"], ["MOCKED-ID"]
-        )
-        self.assertIn("value", opt_results["history"][0].keys())
-        self.assertIn("params", opt_results["history"][0].keys())
 
     def test_optimize_variational_circuit_with_proxy_errors(self):
         client = MockedClient(self.ipaddress, self.port)

--- a/src/python/zquantum/optimizers/daemon_optimizer/optimize/cost_function.py
+++ b/src/python/zquantum/optimizers/daemon_optimizer/optimize/cost_function.py
@@ -1,46 +1,30 @@
-from zquantum.core.interfaces.cost_function import CostFunction
+from zquantum.core.gradients import finite_differences_gradient
 from zquantum.core.utils import save_list, load_value_estimate, ValueEstimate
 from zquantum.core.circuit import save_circuit_template_params
 import time
 import io
 
 
-class ProxyCostFunction(CostFunction):
-    """
-    Implementation of CostFunction interface, which allows to use proxy as cost function.
+class ProxyCostFunction:
+    """Cost function using a proxy.
 
     Args:
-        client (zquantum.core.optimizers.proxy.Client): a client for interacting with
-            the proxy
-        save_evaluation_history (bool): flag indicating whether we want to store the history of all the evaluations.
+        client: a client for interacting with the proxy.
+        epsilon: finite difference step size.
 
     Params:
         evaluations_history (list): List of the tuples (parameters, value) representing all the evaluation in a chronological order.
         save_evaluation_history (bool): see Args
     """
 
-    def __init__(self, client, save_evaluation_history=True, epsilon: float = 1e-5):
-        super().__init__(save_evaluation_history=save_evaluation_history)
+    def __init__(self, client, epsilon: float = 1e-5):
         self.client = client
         self.current_iteration = 0
         self.epsilon = epsilon
+        self.gradient = finite_differences_gradient(self.__call__)
 
-    def evaluate(self, parameters) -> ValueEstimate:
-        """
-        Evaluates the value of the cost function for given parameters.
-
-        Args:
-            parameters (np.ndarray): parameters for which the evaluation should occur
-
-        Returns:
-            value: cost function value for given parameters, either int or float.
-        """
-        value = self._evaluate(parameters)
-        return value
-
-    def _evaluate(self, parameters) -> ValueEstimate:
-        """
-        Evaluates the value of the cost function for given parameters by communicating with client.
+    def __call__(self, parameters) -> ValueEstimate:
+        """Evaluates the value of the cost function for given parameters by communicating with client.
 
         Args:
             parameters (np.ndarray): parameters for which the evaluation should occur
@@ -67,21 +51,10 @@ class ProxyCostFunction(CostFunction):
         evaluation_string = self.client.get_evaluation_result(evaluation_id)
         value_estimate = load_value_estimate(io.StringIO(evaluation_string))
 
-        # SAVE ID to optimization result['history']
-        if self.save_evaluation_history:
-            if len(self.evaluations_history) < self.current_iteration + 1:
-                self.evaluations_history.append({"optimization-evaluation-ids": []})
-            self.evaluations_history[self.current_iteration][
-                "optimization-evaluation-ids"
-            ].append(evaluation_id)
-            self.evaluations_history[self.current_iteration]["params"] = parameters
-            self.evaluations_history[self.current_iteration]["value"] = value_estimate
-
         return value_estimate
 
     def callback(self, parameters):
-        """
-        Callback function to be executed by the optimizer.
+        """Callback function to be executed by the optimizer.
 
         Args:
             parameters (np.ndarray): parameters for which the evaluation should occur
@@ -89,23 +62,10 @@ class ProxyCostFunction(CostFunction):
         Returns:
             None
         """
-        self.evaluations_history[self.current_iteration]["params"] = parameters
-
         print("\nFinsished Iteration: {}".format(self.current_iteration), flush=True)
         print("Current Parameters: {}".format(parameters), flush=True)
 
         # If getting the value history, perform an evaluation with current parameters
-        if self.save_evaluation_history:
-            self.evaluations_history[self.current_iteration]["value"] = self.evaluate(
-                parameters
-            )
-
-            print(
-                "Current Value: {}".format(
-                    self.evaluations_history[self.current_iteration]["value"]
-                ),
-                flush=True,
-            )
 
         print("Starting Next Iteration...", flush=True)
 

--- a/src/python/zquantum/optimizers/daemon_optimizer/optimize/cost_function_test.py
+++ b/src/python/zquantum/optimizers/daemon_optimizer/optimize/cost_function_test.py
@@ -1,14 +1,12 @@
 import unittest
 import numpy as np
 import os
-from zquantum.core.interfaces.cost_function_test import CostFunctionTests
-
 from .cost_function import ProxyCostFunction
 from .client_mock import MockedClient
 from zquantum.core.utils import ValueEstimate
 
 
-class TestProxyCostFunction(unittest.TestCase, CostFunctionTests):
+class TestProxyCostFunction(unittest.TestCase):
     def setUp(self):
         self.port = "1234"
         self.ipaddress = "testing-ip"
@@ -25,7 +23,7 @@ class TestProxyCostFunction(unittest.TestCase, CostFunctionTests):
         target_value = ValueEstimate(16)
 
         # When
-        value = cost_function.evaluate(params)
+        value = cost_function(params)
 
         # Then
         self.assertEqual(value, target_value)
@@ -40,20 +38,13 @@ class TestProxyCostFunction(unittest.TestCase, CostFunctionTests):
         target_value = ValueEstimate(16)
 
         # When
-        value_1 = cost_function.evaluate(params)
-        value_2 = cost_function.evaluate(params)
+        value_1 = cost_function(params)
+        value_2 = cost_function(params)
         cost_function.callback(params)
-        history = cost_function.evaluations_history
 
         # Then
         self.assertEqual(value_1, target_value)
         self.assertEqual(value_2, target_value)
-        self.assertEqual(len(history), 1)
-        self.assertEqual(
-            history[0]["optimization-evaluation-ids"],
-            ["MOCKED-ID", "MOCKED-ID", "MOCKED-ID"],
-        )
-        np.testing.assert_array_equal(history[0]["params"], params)
-        self.assertEqual(history[0]["value"], target_value)
+
         os.remove("client_mock_evaluation_result.json")
         os.remove("current_optimization_params.json")


### PR DESCRIPTION
This updates optimizers tests to not use `MockCostFunction` which was removed along with `CostFunction` interface.