### PR TITLE
Updating optimize variational circuit to accept dicts

### DIFF
--- a/steps/optimizers.py
+++ b/steps/optimizers.py
@@ -37,7 +37,10 @@ def optimize_variational_circuit(
     # Load qubit operator
     operator = load_qubit_operator(qubit_operator)
 
-    ansatz_specs_dict = yaml.load(ansatz_specs, Loader=yaml.SafeLoader)
+    if isinstance(ansatz_specs, str):
+        ansatz_specs_dict = yaml.load(ansatz_specs, Loader=yaml.SafeLoader)
+    else:
+        ansatz_specs_dict = ansatz_specs
     if ansatz_specs_dict["function_name"] == "QAOAFarhiAnsatz":
         ansatz = create_object(ansatz_specs_dict, cost_hamiltonian=operator)
     else:
@@ -49,8 +52,11 @@ def optimize_variational_circuit(
     else:
         grid = None
     
-    # 
-    optimizer_specs_dict = yaml.load(optimizer_specs, Loader=yaml.SafeLoader)
+    # Load optimizer specs
+    if isinstance(optimizer_specs, str):
+        optimizer_specs_dict = yaml.load(optimizer_specs, Loader=yaml.SafeLoader)
+    else:
+        optimizer_specs_dict = optimizer_specs
     if (
         grid is not None
         and optimizer_specs_dict["function_name"] == "GridSearchOptimizer"
@@ -59,7 +65,11 @@ def optimize_variational_circuit(
     else:
         optimizer = create_object(optimizer_specs_dict)
 
-    backend_specs_dict = yaml.load(backend_specs, Loader=yaml.SafeLoader)
+    # Load backend specs
+    if isinstance(backend_specs, str):
+        backend_specs_dict = yaml.load(backend_specs, Loader=yaml.SafeLoader)
+    else:
+        backend_specs_dict = backend_specs
     if noise_model != "None":
         backend_specs_dict["noise_model"] = load_noise_model(noise_model)
     if device_connectivity != "None":
@@ -68,7 +78,11 @@ def optimize_variational_circuit(
         )
     backend = create_object(backend_specs_dict)
 
-    cost_function_specs_dict = yaml.load(cost_function_specs, Loader=yaml.SafeLoader)
+    # Load cost function specs
+    if isinstance(cost_function_specs, str):
+        cost_function_specs_dict = yaml.load(cost_function_specs, Loader=yaml.SafeLoader)
+    else:
+        cost_function_specs_dict = cost_function_specs
     estimator_specs = cost_function_specs_dict.pop("estimator-specs", None)
     if estimator_specs is not None:
         cost_function_specs_dict["estimator"] = create_object(estimator_specs)


### PR DESCRIPTION
Specs for ansatz, optimizer, backend, and cost function can now be provided in yaml (rather than as a string):

```yaml
    - cost_function_specs:
        module_name: zquantum.core.cost_function
        function_name: AnsatzBasedCostFunction
        estimator-specs:
          module_name: zquantum.core.estimator
          function_name: ExactEstimator
      type: specs
```

See also [updated VQE example](https://github.com/zapatacomputing/z-quantum-vqe/blob/e1e68d04203d695d6527903ca468e66f47e62b73/examples/hydrogen-vqe.yaml).