### PR TITLE
Adding prior expectations as input to optimize_variational_circuit

### DIFF
--- a/steps/optimizers.py
+++ b/steps/optimizers.py
@@ -6,7 +6,11 @@ from zquantum.core.circuit import (
 )
 from zquantum.core.openfermion import load_qubit_operator
 from zquantum.core.utils import create_object, load_noise_model
-from zquantum.core.serialization import save_optimization_results, load_optimization_results
+from zquantum.core.measurement import load_expectation_values
+from zquantum.core.serialization import (
+    save_optimization_results,
+    load_optimization_results,
+)
 import yaml
 import numpy as np
 
@@ -23,6 +27,7 @@ def optimize_variational_circuit(
     device_connectivity="None",
     parameter_grid="None",
     constraint_operator="None",
+    prior_expectation_values=None,
 ):
     if initial_parameters != "None":
         initial_params = load_circuit_template_params(initial_parameters)
@@ -51,7 +56,7 @@ def optimize_variational_circuit(
         grid = load_parameter_grid(parameter_grid)
     else:
         grid = None
-    
+
     # Load optimizer specs
     if isinstance(optimizer_specs, str):
         optimizer_specs_dict = yaml.load(optimizer_specs, Loader=yaml.SafeLoader)
@@ -80,7 +85,9 @@ def optimize_variational_circuit(
 
     # Load cost function specs
     if isinstance(cost_function_specs, str):
-        cost_function_specs_dict = yaml.load(cost_function_specs, Loader=yaml.SafeLoader)
+        cost_function_specs_dict = yaml.load(
+            cost_function_specs, Loader=yaml.SafeLoader
+        )
     else:
         cost_function_specs_dict = cost_function_specs
     estimator_specs = cost_function_specs_dict.pop("estimator-specs", None)
@@ -92,9 +99,17 @@ def optimize_variational_circuit(
     cost_function_specs_dict["fixed_parameters"] = fixed_params
     cost_function = create_object(cost_function_specs_dict)
 
+    if prior_expectation_values is not None:
+        if isinstance(prior_expectation_values, str):
+            cost_function.estimator.prior_expectation_values = load_expectation_values(
+                prior_expectation_values
+            )
+
     if constraint_operator != "None":
         constraint_op = load_qubit_operator(constraint_operator)
-        constraints_cost_function_specs = yaml.load(cost_function_specs, Loader=yaml.SafeLoader)
+        constraints_cost_function_specs = yaml.load(
+            cost_function_specs, Loader=yaml.SafeLoader
+        )
         constraints_estimator_specs = constraints_cost_function_specs.pop(
             "estimator-specs", None
         )
@@ -106,9 +121,9 @@ def optimize_variational_circuit(
         constraints_cost_function_specs["backend"] = backend
         constraints_cost_function_specs["target_operator"] = constraint_op
         constraint_cost_function = create_object(constraints_cost_function_specs)
-        constraint_cost_function_wrapper = (
-            lambda params: constraint_cost_function.evaluate(params).value
-        )
+        constraint_cost_function_wrapper = lambda params: constraint_cost_function.evaluate(
+            params
+        ).value
         constraint_functions = (
             {"type": "eq", "fun": constraint_cost_function_wrapper},
         )


### PR DESCRIPTION
This will allow for using optimal shot allocation during VQE optimizations.